### PR TITLE
Character name is now cleared from cache on delete.

### DIFF
--- a/Source/NexusForever.WorldServer/Game/CharacterCache/CharacterManager.cs
+++ b/Source/NexusForever.WorldServer/Game/CharacterCache/CharacterManager.cs
@@ -77,7 +77,7 @@ namespace NexusForever.WorldServer.Game.CharacterCache
         /// <summary>
         /// Used to delete a <see cref="ICharacter"/> from the cache when the <see cref="CharacterModel"/> is deleted
         /// </summary>
-        public void DeleteCharacter(ulong id)
+        public void DeleteCharacter(ulong id, string name)
         {
             if (!characters.ContainsKey(id))
                 throw new ArgumentNullException(nameof(id));
@@ -85,6 +85,8 @@ namespace NexusForever.WorldServer.Game.CharacterCache
             characters.Remove(id, out ICharacter character);
             if (character == null)
                 throw new ArgumentNullException();
+
+            characterNameToId.Remove(name);
 
             log.Trace($"Removed character {character.Name} (ID: {id}) from the cache due to player delete.");
         }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -477,7 +477,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 session.CanProcessPackets = true;
 
                 ResidenceManager.Instance.RemoveResidence(characterToDelete.Name);
-                CharacterManager.Instance.DeleteCharacter(characterToDelete.Id);
+                CharacterManager.Instance.DeleteCharacter(characterToDelete.Id, characterToDelete.Name);
 
                 session.EnqueueMessageEncrypted(new ServerCharacterDeleteResult
                 {


### PR DESCRIPTION
This fixes an exception being thrown when creating a new character with the name of a previously deleted character.